### PR TITLE
Optimize load images for very slow devices with compressing.

### DIFF
--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlHttpImageGetter.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlHttpImageGetter.java
@@ -213,7 +213,7 @@ public class HtmlHttpImageGetter implements ImageGetter {
 
         private float getScale(Drawable drawable) {
             View container = containerReference.get();
-            if (!matchParentWidth && container == null) {
+            if (!matchParentWidth || container == null) {
                 return 1f;
             }
 


### PR DESCRIPTION
Hi, I often see OutOfMemory that associated with load images on slow devices. I was add compression for loaded images and close all streams for clear memory. You can quickly add this changes in new release, that I can update library in my project?