### PR TITLE
 change compile to implementation

### DIFF
--- a/HtmlTextView/build.gradle
+++ b/HtmlTextView/build.gradle
@@ -23,5 +23,5 @@ publish {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:25.0.0'
+    implementation 'com.android.support:support-annotations:25.0.0'
 }


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html