### PR TITLE
Fix gradle sync error: "failed to resolve: runtime"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
@@ -11,8 +11,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
Changing order od the repositories fixes gradle sync error: **"failed to resolve: runtime"**

android-studio-3.2-repo-fix